### PR TITLE
Fix off-by-one error in TJsonReader.MatchString

### DIFF
--- a/pascal/jsonstream.pas
+++ b/pascal/jsonstream.pas
@@ -582,7 +582,9 @@ var
 begin
   Result := false;
 
-  RefillBuffer(Length(Str));
+  // +1 because we need to check if the character after the string as a word
+  // boundary
+  RefillBuffer(Length(Str) + 1);
 
   if FLen < length(Str) then
     exit;


### PR DESCRIPTION
We need to reserve an additional character to check if the following
character is a word boundary.